### PR TITLE
adding AED as a supported currency

### DIFF
--- a/twocheckout/wc-twocheckout.php
+++ b/twocheckout/wc-twocheckout.php
@@ -69,7 +69,7 @@ function woocommerce_twocheckout(){
          * @return bool
          */
         function is_valid_for_use() {
-            if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_twocheckout_supported_currencies', array( 'AUD', 'BRL', 'CAD', 'MXN', 'NZD', 'HKD', 'SGD', 'USD', 'EUR', 'JPY', 'TRY', 'NOK', 'CZK', 'DKK', 'HUF', 'ILS', 'MYR', 'PHP', 'PLN', 'SEK', 'CHF', 'TWD', 'THB', 'GBP', 'RMB' ) ) ) ) return false;
+            if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_twocheckout_supported_currencies', array( 'AUD', 'AED', 'BRL', 'CAD', 'MXN', 'NZD', 'HKD', 'SGD', 'USD', 'EUR', 'JPY', 'TRY', 'NOK', 'CZK', 'DKK', 'HUF', 'ILS', 'MYR', 'PHP', 'PLN', 'SEK', 'CHF', 'TWD', 'THB', 'GBP', 'RMB' ) ) ) ) return false;
 
             return true;
         }


### PR DESCRIPTION
AED was not a supported currency in the previous version, preventing anyone who wanted to use that currency from activating the 2Checkout api extension. This should resolve that. 

Also, there's a lot of currencies in this list that I don't think we support, wondering if we should remove them.
