### PR TITLE
Update the supported currencies

### DIFF
--- a/twocheckout/wc-twocheckout.php
+++ b/twocheckout/wc-twocheckout.php
@@ -85,7 +85,7 @@ function woocommerce_twocheckout(){
          * @return bool
          */
         function is_valid_for_use() {
-            if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_twocheckout_supported_currencies', array( 'AUD', 'AED', 'BRL', 'CAD', 'MXN', 'NZD', 'HKD', 'SGD', 'USD', 'EUR', 'JPY', 'TRY', 'NOK', 'DKK', 'ILS', 'MYR', 'PHP', 'SEK', 'CHF', 'GBP', 'ARS', 'INR', 'LTL', 'RON', 'RUB', 'ZAR' ) ) ) ) return false;
+            if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_twocheckout_supported_currencies', array( 'IDR', 'AUD', 'AED', 'BRL', 'CAD', 'MXN', 'NZD', 'HKD', 'SGD', 'USD', 'EUR', 'JPY', 'TRY', 'NOK', 'DKK', 'ILS', 'MYR', 'PHP', 'SEK', 'CHF', 'GBP', 'ARS', 'INR', 'LTL', 'RON', 'RUB', 'ZAR' ) ) ) ) return false;
 
             return true;
         }

--- a/twocheckout/wc-twocheckout.php
+++ b/twocheckout/wc-twocheckout.php
@@ -85,7 +85,19 @@ function woocommerce_twocheckout(){
          * @return bool
          */
         function is_valid_for_use() {
-            if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_twocheckout_supported_currencies', array( 'IDR', 'AUD', 'AED', 'BRL', 'CAD', 'MXN', 'NZD', 'HKD', 'SGD', 'USD', 'EUR', 'JPY', 'TRY', 'NOK', 'DKK', 'ILS', 'MYR', 'PHP', 'SEK', 'CHF', 'GBP', 'ARS', 'INR', 'LTL', 'RON', 'RUB', 'ZAR' ) ) ) ) return false;
+          $supported_currencies = array(
+            'AFN', 'ALL', 'DZD', 'ARS', 'AUD', 'AZN', 'BSD', 'BDT', 'BBD',
+            'BZD', 'BMD', 'BOB', 'BWP', 'BRL', 'GBP', 'BND', 'BGN', 'CAD',
+            'CLP', 'CNY', 'COP', 'CRC', 'HRK', 'CZK', 'DKK', 'DOP', 'XCD',
+            'EGP', 'EUR', 'FJD', 'GTQ', 'HKD', 'HNL', 'HUF', 'INR', 'IDR',
+            'ILS', 'JMD', 'JPY', 'KZT', 'KES', 'LAK', 'MMK', 'LBP', 'LRD',
+            'MOP', 'MYR', 'MVR', 'MRO', 'MUR', 'MXN', 'MAD', 'NPR', 'TWD',
+            'NZD', 'NIO', 'NOK', 'PKR', 'PGK', 'PEN', 'PHP', 'PLN', 'QAR',
+            'RON', 'RUB', 'WST', 'SAR', 'SCR', 'SGF', 'SBD', 'ZAR', 'KRW',
+            'LKR', 'SEK', 'CHF', 'SYP', 'THB', 'TOP', 'TTD', 'TRY', 'UAH',
+            'AED', 'USD', 'VUV', 'VND', 'XOF', 'YER');
+
+            if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_twocheckout_supported_currencies', $supported_currencies ) ) ) return false;
 
             return true;
         }


### PR DESCRIPTION
This PR will update the currently, and officially, supported currencies:
http://help.2checkout.com/articles/Knowledge_Article/2Checkout-Offers-87-Currency-Options

The code only contains the list of currencies supported in the US since there is no check of which country that the WooCommerce store is operating in.

It has been confirmed and working for the addition of **IDR** as of commit 9accc73
